### PR TITLE
make bitfield a view of bytes

### DIFF
--- a/include/zero_cost_serialization/bitfield.h
+++ b/include/zero_cost_serialization/bitfield.h
@@ -99,7 +99,7 @@ namespace zero_cost_serialization {
 	(std::disjunction_v<std::is_integral<decltype(Ts::value)>, std::is_enum<decltype(Ts::value)>> and ...) and
 	((std::numeric_limits<zero_cost_serialization::detail::corresponding_unsigned_type<detail::underlying_integral<decltype(Ts::value)>>>::digits
 	>= static_cast<detail::underlying_integral<decltype(Ts::value)>>(Ts::value)) and ...)
-	struct bitfield
+	struct bitfield : std::ranges::view_interface<bitfield<Ts...>>
 	{
 	private:
 		using common_type = typename std::conditional_t<bool(sizeof...(Ts)),
@@ -487,6 +487,23 @@ namespace zero_cost_serialization {
 				static_assert((std::same_as<std::remove_cvref_t<Us>, decltype(get_value<Is>())> and ...));
 				(set_value<Is>(std::forward<Us>(us)), ...);
 			}(std::index_sequence_for<Us...>());
+		}
+
+		constexpr auto begin() noexcept
+		{
+			return s.begin();
+		}
+		constexpr auto end() noexcept
+		{
+			return s.end();
+		}
+		constexpr auto begin() const noexcept
+		{
+			return s.begin();
+		}
+		constexpr auto end() const noexcept
+		{
+			return s.end();
 		}
 
 		template <typename T>

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -178,6 +178,12 @@ static_assert(std::same_as<decltype(zero_cost_serialization::strict_alias_cast<c
 static_assert(std::same_as<decltype(zero_cost_serialization::strict_alias_cast<const char&&>(std::declval<const int&&>())), const char&&>);
 static_assert(std::same_as<decltype(zero_cost_serialization::strict_alias_cast<const char&>(std::declval<const int&>())), const char&>);
 
+static_assert(std::is_standard_layout_v<zero_cost_serialization::bitfield<zero_cost_serialization::float_constant<float, 24, 8, u32>>>);
+static_assert(std::is_trivially_copyable_v<zero_cost_serialization::bitfield<zero_cost_serialization::float_constant<float, 24, 8, u32>>>);
+static_assert(std::ranges::sized_range<zero_cost_serialization::bitfield<zero_cost_serialization::float_constant<float, 24, 8, u32>>>);
+static_assert(std::ranges::contiguous_range<zero_cost_serialization::bitfield<zero_cost_serialization::float_constant<float, 24, 8, u32>>>);
+static_assert(std::ranges::view<zero_cost_serialization::bitfield<zero_cost_serialization::float_constant<float, 24, 8, u32>>>);
+
 #include <iostream>
 
 template <typename... Ts>


### PR DESCRIPTION
this allows easy copying to/from byte arrays, which is the use case broadly.